### PR TITLE
Add overlord.yml (MAC-4183)

### DIFF
--- a/overlord.yml
+++ b/overlord.yml
@@ -1,0 +1,19 @@
+# overlord.yml — repo metadata consumed by Overlord (https://github.com/clio/overlord).
+# Added as part of MAC-4183 to onboard this repo to the Overlord dashboard.
+# 'classification' and 'tier' are best-guess deductions from the repo contents; please
+# confirm them. Fields marked TODO could not be deduced and must be filled by the owners.
+# Docs: https://github.com/clio/overlord/blob/master/README.md#using-overlord-on-your-repo
+
+classification: application
+tier: 4                       # Application criticality tier [1-4] — please confirm
+monorepo: false
+owners:                       # TODO: GitHub username(s) of the repo owner(s)
+  # - your-github-username
+team:                         # TODO: GitHub team slug (github.com/orgs/<org>/teams/<team>)
+slack_name:                   # TODO: team Slack channel, e.g. "#your-team"
+backlog_url: https://github.com/cloudpbx/monster-ui-voip-otf/issues
+deploy_url:                   # TODO: deployment system URL
+exceptions_url:               # TODO: error tracking URL (e.g. Bugsnag)
+logging_url:                  # TODO: log aggregation URL
+monitoring_url:               # TODO: APM / monitoring URL
+production_url:               # TODO: production URL

--- a/overlord.yml
+++ b/overlord.yml
@@ -1,19 +1,6 @@
-# overlord.yml — repo metadata consumed by Overlord (https://github.com/clio/overlord).
-# Added as part of MAC-4183 to onboard this repo to the Overlord dashboard.
-# 'classification' and 'tier' are best-guess deductions from the repo contents; please
-# confirm them. Fields marked TODO could not be deduced and must be filled by the owners.
-# Docs: https://github.com/clio/overlord/blob/master/README.md#using-overlord-on-your-repo
-
+# overlord.yml — repo metadata for Overlord (https://github.com/clio/overlord). Added via MAC-4183.
+tier: 4
 classification: application
-tier: 4                       # Application criticality tier [1-4] — please confirm
-monorepo: false
-owners:                       # TODO: GitHub username(s) of the repo owner(s)
-  # - your-github-username
-team:                         # TODO: GitHub team slug (github.com/orgs/<org>/teams/<team>)
-slack_name:                   # TODO: team Slack channel, e.g. "#your-team"
-backlog_url: https://github.com/cloudpbx/monster-ui-voip-otf/issues
-deploy_url:                   # TODO: deployment system URL
-exceptions_url:               # TODO: error tracking URL (e.g. Bugsnag)
-logging_url:                  # TODO: log aggregation URL
-monitoring_url:               # TODO: APM / monitoring URL
-production_url:               # TODO: production URL
+team: corvum
+owners:
+  - uhiku


### PR DESCRIPTION
## Add `overlord.yml`

Adds an `overlord.yml` file so this repo is picked up by [Overlord](https://github.com/clio/overlord/), Clio's repo-metadata / security dashboard.

Part of [MAC-4183](https://linear.app/clio/issue/MAC-4183/add-overlordyml-files-to-all-repos-in-all-orgs) — adding `overlord.yml` to all repos across these orgs.

### What was filled in automatically
- `classification: application` — deduced from the repo's contents/structure (**please confirm**).
- `tier` — best-guess criticality tier (**please confirm**).
- `backlog_url` — set to this repo's GitHub Issues (where applicable).
- `monorepo` — set from repo structure (where applicable).

### What needs your input (`# TODO` in the file)
Fields that can't be inferred from the repo are stubbed with `# TODO` comments — e.g. `owners`, `team`, `slack_name`, and (for applications) `deploy_url`, `exceptions_url`, `logging_url`, `monitoring_url`, `production_url`. Please fill these in or use GitHub's suggestion feature.

See the [overlord.yml docs](https://github.com/clio/overlord/blob/master/README.md#using-overlord-on-your-repo) for the full field reference.

_Opened as a **draft** — this was auto-generated; review the classification/tier and complete the TODOs before merging._